### PR TITLE
throw err if images dir is empty to avoid infinite loop

### DIFF
--- a/internal/encrypt/encrypt.go
+++ b/internal/encrypt/encrypt.go
@@ -177,7 +177,7 @@ func (e *Encrypter) getImages(count int) ([]string, error) {
 	// TODO we can improve this
 	lenImages := len(images)
 	if lenImages == 0 {
-		return nil, errors.New("no image files in /images dir: run 'stego images' to get some random pics")
+		return nil, errors.Errorf("no image files in %s dir: run 'stego images' to get some random pics", dir)
 	}
 	for lenImages < count {
 		images = append(images, images...)

--- a/internal/encrypt/encrypt.go
+++ b/internal/encrypt/encrypt.go
@@ -176,6 +176,9 @@ func (e *Encrypter) getImages(count int) ([]string, error) {
 
 	// TODO we can improve this
 	lenImages := len(images)
+	if lenImages == 0 {
+		return nil, errors.New("no image files in /images dir: run 'stego images' to get some random pics")
+	}
 	for lenImages < count {
 		images = append(images, images...)
 		lenImages = len(images)


### PR DESCRIPTION
This small fix prevents the code to hang indefinetely because of the infinite loop at line 179 when the `/images` dir is empty.