### PR TITLE
create out dir if it does not exist granting all permissions to the owner

### DIFF
--- a/internal/encrypt/encrypt.go
+++ b/internal/encrypt/encrypt.go
@@ -97,7 +97,6 @@ func (e *Encrypter) generateAndSaveMasterKey(filename string) ([]byte, error) {
 	}
 
 	if err := os.MkdirAll(outDirName, 0744); err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR fixes the issue of the program exiting in err due to the `/out` dir not being present. It creates such dir by granting to the owner all permissions.