### PR TITLE
Fix/issue #2: Lorem picsum client hangs

### DIFF
--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/enrichman/stegosecrets/pkg/file"
 	"github.com/spf13/cobra"
@@ -28,9 +29,11 @@ func newImagesCmd() *cobra.Command {
 	return imagesCmd
 }
 
+var client = http.Client{Timeout: 30 * time.Second}
+
 func runImagesCmd(cmd *cobra.Command, args []string) error {
 	for i := 1; i <= 10; i++ {
-		resp, err := http.Get(fmt.Sprintf("https://picsum.photos/%d/%d", width, height))
+		resp, err := client.Get(fmt.Sprintf("https://picsum.photos/%d/%d", width, height))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As said in the commit message:
```
It seems the only reasonable thing to do, since the service does not enforce rate limiting as per this blogpost: https://dmarby.se/blog/lorem-picsum/.
Only clients generating a very high load are blocked at their cache layer.
```
I don't know if the timeout should be configurable via flag.