### PR TITLE
Fix for absolute path and added images dir flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 images/*
-out/
+out/*
 dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,12 @@
 run:
   go: "1.19"
 
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - funlen
+
 linters:
   enable-all: true
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enrichman/stegosecrets
 
-go 1.18
+go 1.19
 
 require (
 	github.com/auyer/steganography v1.0.1

--- a/internal/cli/encrypt.go
+++ b/internal/cli/encrypt.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"path/filepath"
 
 	"github.com/enrichman/stegosecrets/internal/encrypt"
 	"github.com/enrichman/stegosecrets/internal/log"
@@ -15,6 +16,7 @@ var (
 	keyParts      int
 	keyThreshold  int
 	outputDir     string
+	imagesDir     string
 )
 
 func newEncryptCmd() *cobra.Command {
@@ -28,7 +30,8 @@ func newEncryptCmd() *cobra.Command {
 	encryptCmd.Flags().StringVarP(&cleartextFile, "file", "f", "", "file")
 	encryptCmd.Flags().IntVarP(&keyParts, "parts", "p", 0, "parts")
 	encryptCmd.Flags().IntVarP(&keyThreshold, "threshold", "t", 0, "threshold")
-	encryptCmd.Flags().StringVarP(&outputDir, "output", "o", "", "output dir")
+	encryptCmd.Flags().StringVarP(&outputDir, "output", "o", "out", "output dir")
+	encryptCmd.Flags().StringVarP(&imagesDir, "images", "i", "images", "images dir")
 
 	return encryptCmd
 }
@@ -37,6 +40,8 @@ func runEncryptCmd(cmd *cobra.Command, args []string) error {
 	encrypter, err := encrypt.NewEncrypter(
 		encrypt.WithParts(keyParts),
 		encrypt.WithThreshold(keyThreshold),
+		encrypt.WithOutputDir(outputDir),
+		encrypt.WithImagesDir(imagesDir),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed creating encrypter")
@@ -49,11 +54,13 @@ func runEncryptCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	var toEncrypt []byte
+
 	if cleartextFile != "" {
 		toEncrypt, err = file.ReadFile(cleartextFile)
+		cleartextFile = filepath.Base(cleartextFile)
 	} else {
-		cleartextFile = "secret.enc"
 		toEncrypt, err = getInputFromStdin()
+		cleartextFile = "secret"
 	}
 
 	if err != nil {

--- a/internal/encrypt/encrypt_test.go
+++ b/internal/encrypt/encrypt_test.go
@@ -1,46 +1,119 @@
 package encrypt_test
 
 import (
-	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/enrichman/stegosecrets/internal/encrypt"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewEncrypter(t *testing.T) {
-	t.Run("new encrypter with valid options", func(t *testing.T) {
-		threshold := 3
-		parts := 5
+func TestNewEncrypter_WithPartsThreshold(t *testing.T) {
+	type args struct {
+		parts     int
+		threshold int
+	}
 
-		e, err := encrypt.NewEncrypter(encrypt.WithThreshold(threshold), encrypt.WithParts(parts))
+	tt := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid options",
+			args: args{
+				parts:     5,
+				threshold: 3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid threshold",
+			args: args{
+				threshold: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid parts",
+			args: args{
+				parts: 300,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid threshold and parts",
+			args: args{
+				parts:     3,
+				threshold: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid output",
+			args: args{
+				parts:     3,
+				threshold: 5,
+			},
+			wantErr: true,
+		},
+	}
 
-		assert.NotNil(t, e)
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			encrypter, err := encrypt.NewEncrypter(
+				encrypt.WithParts(tc.args.parts),
+				encrypt.WithThreshold(tc.args.threshold),
+			)
+
+			if tc.wantErr {
+				assert.NotNil(t, err)
+				assert.Nil(t, encrypter)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, encrypter)
+			}
+		})
+	}
+}
+
+func TestNewEncrypter_WithOutputDir(t *testing.T) {
+	// it should create the output dir
+	t.Run("non existing dir", func(t *testing.T) {
+		dir := filepath.Join(os.TempDir(), "non-existing-dir")
+		assert.Nil(t, os.RemoveAll(dir))
+
+		_, err := os.Stat(dir)
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+
+		encrypter, err := encrypt.NewEncrypter(
+			encrypt.WithOutputDir(dir),
+		)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, encrypter)
+
+		_, err = os.Stat(dir)
 		assert.Nil(t, err)
 	})
-	t.Run("new encrypter with invalid threshold", func(t *testing.T) {
-		threshold := -1
+}
 
-		e, err := encrypt.NewEncrypter(encrypt.WithThreshold(threshold))
+func TestNewEncrypter_WithImagesDir(t *testing.T) {
+	t.Run("set images dir", func(t *testing.T) {
+		imagesDir := "random"
 
-		assert.Nil(t, e)
-		assert.EqualError(t, err, "invalid threshold")
-	})
-	t.Run("new encrypter with invalid parts", func(t *testing.T) {
-		parts := 300
+		encrypter, err := encrypt.NewEncrypter(
+			encrypt.WithImagesDir(imagesDir),
+		)
 
-		e, err := encrypt.NewEncrypter(encrypt.WithParts(parts))
+		assert.Nil(t, err)
+		assert.NotNil(t, encrypter)
 
-		assert.Nil(t, e)
-		assert.EqualError(t, err, "invalid parts")
-	})
-	t.Run("new encrypter with invalid threshold and parts pair", func(t *testing.T) {
-		threshold := 5
-		parts := 3
-
-		e, err := encrypt.NewEncrypter(encrypt.WithParts(parts), encrypt.WithThreshold(threshold))
-
-		assert.Nil(t, e)
-		assert.EqualError(t, err, fmt.Sprintf("threshold %d cannot exceed the parts %d", threshold, parts))
+		absoluteImagesDir, err := filepath.Abs(imagesDir)
+		assert.Nil(t, err)
+		assert.Equal(t, absoluteImagesDir, encrypter.ImagesDir)
 	})
 }

--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR fixes the issue for the absolute and relative paths.
It also adds the `-i/--images` flag where is possible to specify the folder containing the images where to store the partial keys.

Fixes #35 